### PR TITLE
New Avro schema with multiple "events" in a single json

### DIFF
--- a/insights-notification-schemas-java/src/main/resources/avro/action.avsc
+++ b/insights-notification-schemas-java/src/main/resources/avro/action.avsc
@@ -27,6 +27,13 @@
       "type": "string"
     },
     {
+        "name": "context",
+        "type": {
+            "type": "string",
+            "logicalType": "json-object"
+        }
+    },
+    {
       "name": "events",
       "type": {
         "type": "array",

--- a/insights-notification-schemas-java/src/main/resources/avro/action.avsc
+++ b/insights-notification-schemas-java/src/main/resources/avro/action.avsc
@@ -4,8 +4,8 @@
   "name": "Action",
   "fields": [
     {
-        "name": "bundle",
-        "type": "string"
+      "name": "bundle",
+      "type": "string"
     },
     {
       "name": "application",
@@ -27,12 +27,33 @@
       "type": "string"
     },
     {
-      "name": "payload",
+      "name": "events",
       "type": {
-          "type": "string",
-          "logicalType": "json-object"
-      },
-      "default": "{}"
+        "type": "array",
+        "items": {
+          "name": "Event",
+          "type": "record",
+          "fields": [
+            {
+              "name": "metadata",
+              "type": {
+                "name": "Metadata",
+                "type": "record",
+                "fields": [
+                ]
+              }
+            },
+            {
+              "name": "payload",
+              "type": {
+                "type": "string",
+                "logicalType": "json-object"
+              },
+              "default": "{}"
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestSerialization.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestSerialization.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.ingress;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,17 +23,47 @@ public class TestSerialization {
         targetAction.setTimestamp(LocalDateTime.now());
         targetAction.setEventType("Any");
         targetAction.setAccountId("testTenant");
-        Map<String, String> payload = new HashMap<>();
-        payload.put("k", "v");
-        payload.put("k2", "v2");
-        payload.put("k3", "v");
-        targetAction.setPayload(payload);
+        Map<String, String> context = new HashMap<>();
+        context.put("user_id", "123456-7890");
+        context.put("user_name", "foobar");
+
+        Map<String, String> payload1 = new HashMap<>();
+        payload1.put("k", "v");
+        payload1.put("k2", "v2");
+        payload1.put("k3", "v");
+
+        Map<String, String> payload2 = new HashMap<>();
+        payload2.put("k", "b");
+        payload2.put("k2", "b2");
+        payload2.put("k3", "b");
+
+        ArrayList<Event> events = new ArrayList<>();
+        Event event1 = Event.newBuilder()
+                .setMetadata(Metadata.newBuilder().build())
+                .setPayload(payload1)
+                .build();
+        Event event2 = Event.newBuilder()
+                .setMetadata(Metadata.newBuilder().build())
+                .setPayload(payload2)
+                .build();
+
+        events.add(event1);
+        events.add(event2);
+
+        targetAction.setEvents(events);
+        targetAction.setContext(context);
 
         String serializedAction = serializeAction(targetAction);
 
-        Action action = deserializeAction(serializedAction);
-        assertNotNull(action);
-        assertEquals(targetAction.getAccountId(), action.getAccountId());
-        assertEquals(targetAction.getPayload().get("k3"), action.getPayload().get("k3"));
+        Action deserializedAction = deserializeAction(serializedAction);
+        assertNotNull(deserializedAction);
+        assertEquals(targetAction.getAccountId(), deserializedAction.getAccountId());
+
+        assertEquals("123456-7890", deserializedAction.getContext().get("user_id"));
+        assertEquals("foobar", deserializedAction.getContext().get("user_name"));
+
+        assertEquals(2, deserializedAction.getEvents().size());
+        assertEquals("v2", deserializedAction.getEvents().get(0).getPayload().get("k2"));
+        assertEquals("b2", deserializedAction.getEvents().get(1).getPayload().get("k2"));
     }
 }


### PR DESCRIPTION
  - Each event has its free payload and metadata (currently empty)

New object
```json
{
   "bundle":"rhel",
   "application":"policies",
   "event_type":"policy-triggered",
   "timestamp":"2020-12-08T09:31:39Z",
   "account_id":"000000",
   "context":{
      "anything":"that we want",
      "here.":"'shared' with the events"
   },
   "events":[
      {
         "metadata":{
            "future":"proof"
         },
         "payload":{
            "any":"thing",
            "we":1,
            "want":"here"
         }
      },
      {
         "metadata":{
            "future":"proof"
         },
         "payload":{
            "any":"thing",
            "we":1,
            "want":"here"
         }
      }
   ]
}
```

Concrete example for policies:
```json
{
   "bundle":"rhel",
   "application":"policies",
   "event_type":"policy-triggered",
   "timestamp":"2020-12-08T09:31:39Z",
   "account_id":"000000",
   "context":{
      "insights_id":"8fb85845-2f66-4b60-b126-8d13692befc4",
      "system_check_in":"2020-12-08T09:30:23Z",
      "display_name":"RHEL83",
      "tags":[
         
      ]
   },
   "events":[
      {
         "metadata":{
            
         },
         "payload":{
            "policy_id":"e40ab1a0-206a-43e8-928a-d97fd72783d4",
            "policy_name":"Old RHEL",
            "policy_description":"Triggers if system has an old RHEL version",
            "policy_condition":"facts.os_release < 8.1"
         }
      },
      {
         "metadata":{
            
         },
         "payload":{
            "policy_id":"024b8607-c2c9-49f7-97a4-066b89c69334",
            "policy_name":"Wireshark installed",
            "policy_description":"Triggers if system wireshark is installed in the system",
            "policy_condition":"facts.installed_packages contains ['wireshark']"
         }
      }
   ]
}
```