### PR TITLE
Relax some validations

### DIFF
--- a/insights-notification-schemas-java/pom.xml
+++ b/insights-notification-schemas-java/pom.xml
@@ -27,11 +27,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${json-schema-validator.version}</version>

--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/ingress/Parser.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/ingress/Parser.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.networknt.schema.ApplyDefaultsStrategy;
 import com.networknt.schema.JsonMetaSchema;
 import com.networknt.schema.JsonSchema;
@@ -15,6 +14,7 @@ import com.networknt.schema.SchemaValidatorsConfig;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidatorTypeCode;
 import com.networknt.schema.ValidationResult;
+import com.redhat.cloud.notifications.jackson.LocalDateTimeModule;
 import com.redhat.cloud.notifications.validator.LocalDateTimeValidator;
 
 import java.io.UncheckedIOException;
@@ -30,9 +30,7 @@ public class Parser {
 
     static {
         jsonSchema = getJsonSchema();
-
-        // Provides LocalDateTime support
-        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new LocalDateTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 

--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/LocalDateTimeModule.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/LocalDateTimeModule.java
@@ -1,0 +1,16 @@
+package com.redhat.cloud.notifications.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.redhat.cloud.notifications.jackson.deserializer.LocalDateTimeDeserializer;
+import com.redhat.cloud.notifications.jackson.serializer.LocalDateTimeSerializer;
+
+import java.time.LocalDateTime;
+
+public class LocalDateTimeModule extends SimpleModule {
+
+    public LocalDateTimeModule() {
+        addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
+        addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
+    }
+
+}

--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/deserializer/LocalDateTimeDeserializer.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/deserializer/LocalDateTimeDeserializer.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.notifications.jackson.deserializer;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+
+public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+
+    @Override
+    public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JacksonException {
+        if (jsonParser.hasTokenId(JsonTokenId.ID_STRING)) {
+            // One of the tenants is sending the datetime with a 0-offset - ISO_LOCAL_DATE_TIME fails to parse it.
+            TemporalAccessor temporalAccessor = DateTimeFormatter.ISO_DATE_TIME.parse(jsonParser.getText());
+            return LocalDateTime.from(temporalAccessor);
+        }
+
+        return (LocalDateTime) deserializationContext.handleUnexpectedToken(LocalDateTime.class, jsonParser);
+    }
+}

--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/serializer/LocalDateTimeSerializer.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/serializer/LocalDateTimeSerializer.java
@@ -1,0 +1,18 @@
+package com.redhat.cloud.notifications.jackson.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
+
+    @Override
+    public void serialize(LocalDateTime dateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeString(dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    }
+
+}

--- a/insights-notification-schemas-java/src/main/resources/schemas/Action.json
+++ b/insights-notification-schemas-java/src/main/resources/schemas/Action.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "title": "Notification message",
-  "comment": "Generated with https://hellosean1025.github.io/json-schema-visual-editor/",
+  "$comment": "Generated with https://hellosean1025.github.io/json-schema-visual-editor/",
   "properties": {
     "version": {
       "type": "string",
@@ -63,7 +63,8 @@
             "title": "Event payload"
           }
         },
-        "additionalProperties": false,
+        "$comment": "Accepting additional properties because one tenant is sending them at this level - should be removed once the tenant updates.",
+        "additionalProperties": true,
         "required": [
           "payload"
         ]

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestSerialization.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestSerialization.java
@@ -131,6 +131,14 @@ public class TestSerialization {
          assertEquals(List.of(), otherAction.getRecipients().get(0).getUsers());
      }
 
+     @Test
+     void shouldAcceptExtraPropertiesAtEventLevel() {
+         Action action = getValidAction();
+         action.getEvents().get(0).setAdditionalProperty("report_url", "http://blablabla.com");
+
+         assertDoesNotThrow(() -> Parser.decode(Parser.encode(action)));
+     }
+
     @Test
     void shouldFailWithoutRequiredFieldsWhenSerializing() throws JsonProcessingException {
         Action action = getValidAction();
@@ -207,6 +215,18 @@ public class TestSerialization {
                         22,
                         10,
                         133000000
+                )
+        );
+
+        testDate(
+                "2011-12-03T10:15:30+00:00",
+                LocalDateTime.of(
+                        2011,
+                        12,
+                        3,
+                        10,
+                        15,
+                        30
                 )
         );
     }
@@ -311,7 +331,7 @@ public class TestSerialization {
     /**
      * This method removes a field from a valid template and checks one of these two cases:
      - if {@code isRequired} is true, the field removal should trigger an exception throw when the template is decoded
-     - otherwise, the field removal should not cause any exception during the decoding as the field is expected to be optional 
+     - otherwise, the field removal should not cause any exception during the decoding as the field is expected to be optional
      */
     private void testRequiredField(String field, boolean isRequired, String template) throws JsonProcessingException {
         JsonNode base = objectMapper.readTree(template);

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java
@@ -15,6 +15,9 @@ public class TestLocalDateTimeValidator {
         assertTrue(validator.matches("2020-07-14T13:22:10"));
         assertTrue(validator.matches("2020-07-14T13:22:10Z"));
 
+        // 00:00 offset is fine
+        assertTrue(validator.matches("2011-12-03T10:15:30+00:00"));
+
         // Offsets
         assertFalse(validator.matches("2011-12-03T10:15:30+01:00[Europe/Paris]"));
         assertFalse(validator.matches("2011-12-03T10:15:30[Europe/Paris]"));


### PR DESCRIPTION
 - Allows additional properties at events
 - Parses dates with 0-offsets

Saw a couple of applications where the validations failed, relaxing the validations while we decide how to proceed. 