### PR TITLE
Makes the parser stricter

### DIFF
--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/LocalDateTimeModule.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/LocalDateTimeModule.java
@@ -8,8 +8,8 @@ import java.time.LocalDateTime;
 
 public class LocalDateTimeModule extends SimpleModule {
 
-    public LocalDateTimeModule(boolean relaxed) {
-        addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(relaxed));
+    public LocalDateTimeModule() {
+        addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
         addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
     }
 

--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/deserializer/LocalDateTimeDeserializer.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/deserializer/LocalDateTimeDeserializer.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.jackson.deserializer;
 
-import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonTokenId;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -8,27 +7,20 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 
 public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
 
-    private DateTimeFormatter formatter;
-
-    public LocalDateTimeDeserializer(boolean relaxed) {
-        // One of the tenants is sending the datetime with a 0-offset - ISO_LOCAL_DATE_TIME fails to parse it.
-        if (relaxed) {
-            formatter = DateTimeFormatter.ISO_DATE_TIME;
-        } else {
-            formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-        }
-    }
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC);
 
     @Override
-    public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JacksonException {
+    public LocalDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         if (jsonParser.hasTokenId(JsonTokenId.ID_STRING)) {
-            TemporalAccessor temporalAccessor = formatter.parse(jsonParser.getText());
-            return LocalDateTime.from(temporalAccessor);
+            TemporalAccessor temporalAccessor = dateTimeFormatter.parse(jsonParser.getText());
+            return OffsetDateTime.from(temporalAccessor).atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
         }
 
         return (LocalDateTime) deserializationContext.handleUnexpectedToken(LocalDateTime.class, jsonParser);

--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/serializer/LocalDateTimeSerializer.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/jackson/serializer/LocalDateTimeSerializer.java
@@ -12,7 +12,7 @@ public class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
 
     @Override
     public void serialize(LocalDateTime dateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
-        jsonGenerator.writeString(dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        jsonGenerator.writeString(dateTime.format(DateTimeFormatter.ISO_DATE_TIME));
     }
 
 }

--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/validator/LocalDateTimeValidator.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/validator/LocalDateTimeValidator.java
@@ -4,21 +4,10 @@ import com.networknt.schema.Format;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalAccessor;
 
 public class LocalDateTimeValidator implements Format {
 
     private String message;
-    private DateTimeFormatter formatter;
-
-    public LocalDateTimeValidator(boolean relaxed) {
-        if (relaxed) {
-            formatter = DateTimeFormatter.ISO_DATE_TIME;
-        } else {
-            formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-        }
-    }
 
     @Override
     public String getName() {
@@ -28,11 +17,7 @@ public class LocalDateTimeValidator implements Format {
     @Override
     public boolean matches(String text) {
         try {
-            TemporalAccessor temporalAccessor = formatter.parse(text);
-            if (temporalAccessor.isSupported(ChronoField.OFFSET_SECONDS)) {
-                // Dates and times have to be expressed in UTC. Values with an offset are considered invalid.
-                return temporalAccessor.get(ChronoField.OFFSET_SECONDS) == 0;
-            }
+            DateTimeFormatter.ISO_DATE_TIME.parse(text);
             return true;
         } catch (DateTimeParseException exception) {
             message = exception.getMessage();

--- a/insights-notification-schemas-java/src/main/resources/schemas/Action.json
+++ b/insights-notification-schemas-java/src/main/resources/schemas/Action.json
@@ -69,7 +69,7 @@
           }
         },
         "$comment": "Accepting additional properties because one tenant is sending them at this level - should be removed once the tenant updates.",
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
           "payload"
         ]

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestParser.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestParser.java
@@ -16,9 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestSerialization {
+public class TestParser {
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -152,24 +151,19 @@ public class TestSerialization {
      }
 
      @Test
-     void shouldAcceptExtraPropertiesAtEventLevelWhenDeserializingAndFailIfSerializingOrValidating() {
+     void shouldNotAcceptExtraPropertiesAtEventLevelWhenDeserializingAndFailIfSerializingOrValidating() {
          String jsonAction = "{\"bundle\": \"rhel\", \"application\": \"advisor\", \"event_type\": \"new-recommendation\", \"timestamp\": \"2022-05-02T19:47:15.626507+00:00\", \"account_id\": \"6089719\", \"context\": {}, \"events\": [{\"metadata\": {}, \"payload\": {}, \"report_url\": \"https://console.redhat.com/insights/advisor/recommendations/hardening_grub|GRUB_HARDENING_3/4c548b3c-b816-4d69-97cf-d8046fc10139\"}, {\"metadata\": {}, \"payload\": {}, \"report_url\": \"https://console.redhat.com/insights/advisor/recommendations/insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE/4c548b3c-b816-4d69-97cf-d8046fc10139\"}, {\"metadata\": {}, \"payload\": {}, \"report_url\": \"https://console.redhat.com/insights/advisor/recommendations/wrong_tuned_profile|WRONG_TUNED_PROFILE_USED_FOR_VIRTUAL_GUEST/4c548b3c-b816-4d69-97cf-d8046fc10139\"}]}";
-         Action action = Parser.decode(jsonAction);
-         assertTrue(action.getEvents().get(0).getAdditionalProperties().containsKey("report_url"));
-
-         assertThrows(ParsingException.class, () -> Parser.encode(action));
-         assertThrows(ParsingException.class, () -> Parser.validate(action));
-
+         assertThrows(ParsingException.class, () -> Parser.decode(jsonAction));
          assertThrows(ParsingException.class, () -> Parser.validate(jsonAction));
      }
 
     @Test
-    void shouldAcceptTimestampWith00OffsetWhenDeserializingAndFailIfValidating() {
+    void shouldAcceptTimestampWith00OffsetWhenDeserializingAndValidating() {
         String jsonAction = "{\"version\":\"v1.1.0\",\"bundle\":\"rhel\",\"application\":\"compliance\",\"event_type\":\"compliance-below-threshold\",\"timestamp\":\"2022-05-02T17:30:54+00:00\",\"account_id\":\"6089719\",\"events\":[{\"metadata\":{},\"payload\": {}}],\"context\": {},\"recipients\":[]}";
         Action action = Parser.decode(jsonAction);
         assertEquals(LocalDateTime.of(2022, 5, 2, 17, 30 ,54), action.getTimestamp());
 
-        assertThrows(ParsingException.class, () -> Parser.validate(jsonAction));
+        assertDoesNotThrow(() -> Parser.validate(jsonAction));
     }
 
     @Test
@@ -260,6 +254,34 @@ public class TestSerialization {
                         10,
                         15,
                         30
+                )
+        );
+    }
+
+    @Test
+    void shouldTransformDatesToUtc() {
+        // Dates with offset should be transformed to utc (i.e. without the offset)
+        testDate(
+                "2011-12-03T10:15:30+03:00",
+                LocalDateTime.of(
+                        2011,
+                        12,
+                        3,
+                        7,
+                        15,
+                        30
+                )
+        );
+
+        testDate(
+                "2011-12-03T01:15:30+03:15:15",
+                LocalDateTime.of(
+                        2011,
+                        12,
+                        2,
+                        22,
+                        0,
+                        15
                 )
         );
     }

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java
@@ -17,7 +17,6 @@ public class TestLocalDateTimeValidator {
         // Offsets
         assertTrue(validator.matches("2011-12-03T10:15:30+01:00[Europe/Paris]"));
         assertFalse(validator.matches("2011-12-03T10:15:30[Europe/Paris]"));
-        System.out.println(validator.getErrorMessageDescription());
         assertTrue(validator.matches("2011-12-03T10:15:30+01:00"));
 
         // Week format

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java
@@ -8,16 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestLocalDateTimeValidator {
 
     @Test
-    void shouldMatchIsoDatesInRelaxedMode() {
-        LocalDateTimeValidator validator = new LocalDateTimeValidator(true);
+    void shouldMatchIsoDates() {
+        LocalDateTimeValidator validator = new LocalDateTimeValidator();
 
         assertTrue(validator.matches("2020-07-14T13:22:10.133"));
         assertTrue(validator.matches("2020-07-14T13:22:10"));
 
         // Offsets
-        assertFalse(validator.matches("2011-12-03T10:15:30+01:00[Europe/Paris]"));
+        assertTrue(validator.matches("2011-12-03T10:15:30+01:00[Europe/Paris]"));
         assertFalse(validator.matches("2011-12-03T10:15:30[Europe/Paris]"));
-        assertFalse(validator.matches("2011-12-03T10:15:30+01:00"));
+        System.out.println(validator.getErrorMessageDescription());
+        assertTrue(validator.matches("2011-12-03T10:15:30+01:00"));
 
         // Week format
         assertFalse(validator.matches("2007-W44-6T16:18:05Z"));
@@ -30,38 +31,8 @@ public class TestLocalDateTimeValidator {
         assertFalse(validator.matches("2020-07-14"));
         assertFalse(validator.matches("22:10:10"));
 
-        // Differences with strict mode
         assertTrue(validator.matches("2020-07-14T13:22:10Z"));
         assertTrue(validator.matches("2011-12-03T10:15:30+00:00"));
-
-    }
-
-    @Test
-    void shouldMatchIsoDatesInStrictMode() {
-        LocalDateTimeValidator validator = new LocalDateTimeValidator(false);
-
-        assertTrue(validator.matches("2020-07-14T13:22:10.133"));
-        assertTrue(validator.matches("2020-07-14T13:22:10"));
-
-        // Offsets
-        assertFalse(validator.matches("2011-12-03T10:15:30+01:00[Europe/Paris]"));
-        assertFalse(validator.matches("2011-12-03T10:15:30[Europe/Paris]"));
-        assertFalse(validator.matches("2011-12-03T10:15:30+01:00"));
-
-        // Week format
-        assertFalse(validator.matches("2007-W44-6T16:18:05Z"));
-
-        // Text
-        assertFalse(validator.matches("Tomorrow"));
-        assertFalse(validator.matches("As soon as possible!!"));
-
-        // Only date or time
-        assertFalse(validator.matches("2020-07-14"));
-        assertFalse(validator.matches("22:10:10"));
-
-        // Differences with relaxed mode
-        assertFalse(validator.matches("2020-07-14T13:22:10Z"));
-        assertFalse(validator.matches("2011-12-03T10:15:30+00:00"));
     }
 
 }


### PR DESCRIPTION
 - Support ISO_DATE_TIME codes  If we get an offset, convert to local UTC
 - No longer expect additionalProperties in the event

The applications that were sending additional fields have fixed their messages, we can now remove this data.
As agreed we are accepting timezones - internally we convert them to UTC when parsing.