### PR TITLE
[RHCLOUD-22667] feature: use display names where possible

### DIFF
--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/ingress/Parser.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/ingress/Parser.java
@@ -29,12 +29,15 @@ public class Parser {
     final static ObjectMapper objectMapper = new ObjectMapper();
     private final static JsonSchema jsonSchema;
 
+    private final static String ACTION_SCHEMA_PATH = "/schemas/Action.json";
+    private final static String ACTION_OUT_SCHEMA_PATH = "/schemas/Action-out.json";
+
     private final static String CONTEXT_FIELD = "context";
     private final static String EVENTS_FIELD = "events";
     private final static String PAYLOAD_FIELD = "payload";
 
     static {
-        jsonSchema = getJsonSchema();
+        jsonSchema = getJsonSchema(ACTION_SCHEMA_PATH);
         objectMapper.registerModule(new LocalDateTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
@@ -113,6 +116,16 @@ public class Parser {
         }
     }
 
+    /**
+     * Validates an "Action out" and ensures that all the values conform to the schema.
+     * @param actionOut ActionOut to be validated.
+     */
+    public static void validate(final ActionOut actionOut) {
+        final JsonSchema actionOutJsonSchema = getJsonSchema(ACTION_OUT_SCHEMA_PATH);
+
+        validate(objectMapper.valueToTree(actionOut), actionOutJsonSchema);
+    }
+
     // context and events[].payload could be strings, change these values to jsons objects.
     private static void updateContextAndPayload(JsonNode action, ObjectMapper objectMapper) throws JsonProcessingException {
         parseFieldIfNeeded(action, CONTEXT_FIELD, objectMapper);
@@ -136,7 +149,7 @@ public class Parser {
         }
     }
 
-    private static JsonSchema getJsonSchema() {
+    private static JsonSchema getJsonSchema(final String schemaPath) {
         SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
         schemaValidatorsConfig.setApplyDefaultsStrategy(new ApplyDefaultsStrategy(
                 true,
@@ -144,7 +157,7 @@ public class Parser {
                 true
         ));
 
-        try (InputStream jsonSchemaStream = Parser.class.getResourceAsStream("/schemas/Action.json")) {
+        try (InputStream jsonSchemaStream = Parser.class.getResourceAsStream(schemaPath)) {
             JsonNode schema = objectMapper.readTree(jsonSchemaStream);
 
             return jsonSchemaFactory().getSchema(

--- a/insights-notification-schemas-java/src/main/resources/schemas/Action-out.json
+++ b/insights-notification-schemas-java/src/main/resources/schemas/Action-out.json
@@ -1,0 +1,82 @@
+{
+  "$comment": "This schema defines some additional information for an Action that might be useful",
+  "additionalProperties": false,
+  "description": "Describes additional information fields for some of the fields of the Action",
+  "title": "Action's details",
+  "type": "object",
+  "properties": {
+    "version": {},
+    "id": {},
+    "bundle": {},
+    "application": {},
+    "event_type": {},
+    "timestamp": {},
+    "account_id": {},
+    "org_id": {},
+    "context": {},
+    "events": {},
+    "recipients": {},
+    "source": {
+      "additionalProperties": false,
+      "description": "The extended details related to the Action",
+      "title": "Source",
+      "type": "object",
+      "properties": {
+        "application": {
+          "additionalProperties": false,
+          "description": "Represents the extra information for the application object",
+          "title": "Application",
+          "type": "object",
+          "properties": {
+            "display_name": {
+              "description": "A user friendly version of the application's name",
+              "minLength": 1,
+              "required": true,
+              "title": "The application's display name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "display_name"
+          ]
+        },
+        "bundle": {
+          "additionalProperties": false,
+          "description": "Represents the extra information for the bundle object",
+          "title": "Bundle",
+          "type": "object",
+          "properties": {
+            "display_name": {
+              "description": "A user friendly version of the bundle's name",
+              "minLength": 1,
+              "required": true,
+              "title": "Bundle's display name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "display_name"
+          ]
+        },
+        "event_type": {
+          "additionalProperties": false,
+          "description": "Represents the extra information for the event type object",
+          "title": "Event Type",
+          "type": "object",
+          "properties": {
+            "display_name": {
+              "description": "A user friendly version of the event type's name",
+              "minLength": 1,
+              "required": true,
+              "title": "Event type's display name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "display_name"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Enables using the display names for the objects that allow to do so, which will help making the notifications more user friendly.

I'm not sure if I like this solution, because this makes the generator create classes with a `__1` in their name, because they clash with existing ones...

The other option would be to bump the major version, which would imply these kind of breaking changes?

## Links

[[RHCLOUD-22667]](https://issues.redhat.com/browse/RHCLOUD-22667)