### PR TITLE
RHCLOUD-29101 Introduce recipients.emails field

### DIFF
--- a/insights-notification-schemas-java/src/main/resources/schemas/Action.json
+++ b/insights-notification-schemas-java/src/main/resources/schemas/Action.json
@@ -102,6 +102,15 @@
             "title": "Users",
             "description": "List of users to direct the notification to. Note that this does not ignore the user preferences."
           },
+          "emails": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Emails",
+            "description": "List of emails to direct the notification to. Note that this does not ignore the user preferences."
+          },
           "groups": {
             "type": "array",
             "default": [],

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestParser.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestParser.java
@@ -152,6 +152,7 @@ public class TestParser {
          action.getRecipients().get(0).setOnlyAdmins(null);
          action.getRecipients().get(0).setGroups(null);
          action.getRecipients().get(0).setUsers(null);
+         action.getRecipients().get(0).setEmails(null);
 
          otherAction = Parser.decode(Parser.encode(action));
 
@@ -159,6 +160,7 @@ public class TestParser {
          assertEquals(Boolean.FALSE, otherAction.getRecipients().get(0).getOnlyAdmins());
          assertEquals(List.of(), otherAction.getRecipients().get(0).getGroups());
          assertEquals(List.of(), otherAction.getRecipients().get(0).getUsers());
+         assertEquals(List.of(), otherAction.getRecipients().get(0).getEmails());
      }
 
      @Test


### PR DESCRIPTION
This will be used by OCM to include email addresses as recipients in the requests they'll send to `notifications-gw`.