### PR TITLE
[RHCLOUD-41535] Allow severity field to be null

### DIFF
--- a/insights-notification-schemas-java/src/main/resources/schemas/Action.json
+++ b/insights-notification-schemas-java/src/main/resources/schemas/Action.json
@@ -43,7 +43,7 @@
       "title": "Organization id"
     },
     "severity": {
-      "type": "string",
+      "type": [ "string", "null" ],
       "title": "Severity",
       "description": "Overall severity of the notification. If events of varying severity are provided, use the highest level."
     },

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestParser.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/ingress/TestParser.java
@@ -353,6 +353,11 @@ public class TestParser {
         );
     }
 
+    @Test
+    void shouldAcceptNullSeverity() {
+        assertDoesNotThrow(() -> Parser.decode("{\"severity\":null,\"version\":\"v1.1.0\",\"id\":\"44bb1963-0881-4730-b0b3-afc387048bc1\",\"bundle\":\"test-bundle\",\"application\":\"Policies\",\"event_type\":\"any\",\"timestamp\":\"2025-09-24T10:41:41.618865429\",\"org_id\":\"test-org-id\",\"events\":[],\"recipients\":[],\"context\":{}}"));
+    }
+
     /**
      * Validate that when an "action-out" that is properly built is validated,
      * it doesn't generate any validation errors.


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-41535

Slight adjustment to the Action.json schema to allow for null values. This handles an edge case in notifications-backend (`EmailAggregationProcessorTest`) where a field is encoded with the field as JSON `null`, but then cannot be decoded.

Added `shouldAcceptNullSeverity` test case to validate.