### PR TITLE
RHCLOUD-49846: fix(validator): make LocalDateTimeValidator thread-safe with ThreadLocal

### DIFF
--- a/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/validator/LocalDateTimeValidator.java
+++ b/insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/validator/LocalDateTimeValidator.java
@@ -8,7 +8,7 @@ import java.time.format.DateTimeParseException;
 
 public class LocalDateTimeValidator implements Format {
 
-    private String message;
+    private final ThreadLocal<String> message = new ThreadLocal<>();
 
     @Override
     public String getName() {
@@ -23,15 +23,18 @@ public class LocalDateTimeValidator implements Format {
     public boolean matches(String text) {
         try {
             DateTimeFormatter.ISO_DATE_TIME.parse(text);
+            message.remove();
             return true;
         } catch (DateTimeParseException exception) {
-            message = exception.getMessage();
+            message.set(exception.getMessage());
             return false;
         }
     }
 
     @Override
     public String getMessageKey() {
-        return message;
+        String result = message.get();
+        message.remove();
+        return result;
     }
 }

--- a/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java
+++ b/insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java
@@ -2,7 +2,15 @@ package com.redhat.cloud.notifications.validator;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLocalDateTimeValidator {
@@ -32,6 +40,58 @@ public class TestLocalDateTimeValidator {
 
         assertTrue(validator.matches("2020-07-14T13:22:10Z"));
         assertTrue(validator.matches("2011-12-03T10:15:30+00:00"));
+    }
+
+    @Test
+    void shouldExposeMessageKeyOnlyAfterFailedMatch() {
+        LocalDateTimeValidator validator = new LocalDateTimeValidator();
+
+        assertFalse(validator.matches("Tomorrow"));
+        assertTrue(validator.getMessageKey().contains("Tomorrow"));
+
+        // getMessageKey() clears the captured message after reading it
+        assertNull(validator.getMessageKey());
+
+        assertTrue(validator.matches("2020-07-14T13:22:10Z"));
+        assertNull(validator.getMessageKey());
+    }
+
+    @Test
+    void shouldNotLeakMessagesAcrossThreads() throws InterruptedException {
+        LocalDateTimeValidator validator = new LocalDateTimeValidator();
+        int threadCount = 20;
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        List<String> failures = new CopyOnWriteArrayList<>();
+
+        List<Thread> threads = IntStream.range(0, threadCount)
+            .mapToObj(i -> new Thread(() -> {
+                String input = "not-a-date-" + i;
+                try {
+                    ready.countDown();
+                    start.await();
+
+                    boolean matched = validator.matches(input);
+                    String messageKey = validator.getMessageKey();
+
+                    if (matched || messageKey == null || !messageKey.contains(input)) {
+                        failures.add("Thread " + i + " observed unexpected messageKey: " + messageKey);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            }))
+            .collect(Collectors.toList());
+
+        threads.forEach(Thread::start);
+        ready.await();
+        start.countDown();
+        done.await();
+
+        assertEquals(List.of(), failures);
     }
 
 }


### PR DESCRIPTION
## Executive Summary
- `LocalDateTimeValidator` is registered as a single process-wide singleton `Format` (via `Parser`'s static schema), so its mutable `message` instance field was shared and unsynchronized across concurrent validation threads.
- Under concurrent multi-tenant use, this allowed one tenant's malformed timestamp string to leak into another tenant's error message.
- Fixes it by moving `message` to a `ThreadLocal<String>`, cleared on both the success path and after `getMessageKey()` reads it — no cross-thread visibility, no residual state beyond a single validation call.

## Detailed Implementation Summary
- **Modified:** `insights-notification-schemas-java/src/main/java/com/redhat/cloud/notifications/validator/LocalDateTimeValidator.java` — replaced `private String message` with `private final ThreadLocal<String> message`; `matches()` sets it on failure and clears it on success; `getMessageKey()` reads then clears it.
- **Modified:** `insights-notification-schemas-java/src/test/java/com/redhat/cloud/notifications/validator/TestLocalDateTimeValidator.java` — added `shouldExposeMessageKeyOnlyAfterFailedMatch` (verifies clear-on-read semantics) and `shouldNotLeakMessagesAcrossThreads` (20-thread concurrency test using `CountDownLatch` to force contention and assert no cross-thread message leakage).
- **Tests:** full module suite passes — 24/24 (`mvn -pl insights-notification-schemas-java -am test`).
- **Pre-commit review:** ran the `pr-review-fix` 4-pass cycle (Opus, Gemini, Opus, Sonnet-arbiter). Gemini pass failed/skipped (model unavailable in this deployment). Opus pass 1 caught and fixed a real defect: the new concurrency test used `Stream.toList()`, a Java 16+ API, which would have broken CI (`--release 11` target). Passes 3 and 4 independently verified the `ThreadLocal` fix against the actual pinned `json-schema-validator:2.0.1` library contract and found no further issues.
- **Known gaps:** none identified.

## Jira
https://redhat.atlassian.net/browse/RHCLOUD-50508 (sub-task of RHCLOUD-49846, FIND-005 security audit finding)

## Checklist
- [x] Existing tests pass
- [x] New tests added covering the fix
- [x] No API/behavior contract broken (verified against actual library usage pattern)
